### PR TITLE
Typo `instealled` -> `installed` and some grammar "improvements"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,9 +6,9 @@ SPDX-License-Identifier: MPL-2.0
 
 # Contributing to CC: Tweaked
 As with many open source projects, CC: Tweaked thrives on contributions from other people! This document (hopefully)
-provides an introduction as to how to get started in helping out.
+provides an introduction as to how to get started to help.
 
-If you've any other questions, [just ask the community][community] or [open an issue][new-issue].
+If you've got any other questions, [just ask the community][community] or [open an issue][new-issue].
 
 ## Table of Contents
  - [Reporting issues](#reporting-issues)
@@ -28,7 +28,7 @@ automatically with GitHub, so please don't submit PRs adding/changing translatio
 ## Setting up a development environment
 In order to develop CC: Tweaked, you'll need to download the source code and then run it.
 
- - Make sure you've got the following software instealled:
+ - Make sure you've got the following software installed:
    - Java Development Kit (JDK) installed. This can be downloaded from [Adoptium].
    - [Git](https://git-scm.com/).
    - If you want to work on documentation, [NodeJS][node].
@@ -51,10 +51,10 @@ If you want to run CC:T in a normal Minecraft instance, run `./gradlew assemble`
 ## Developing CC: Tweaked
 Before making any major changes to CC: Tweaked, I'd recommend you have a read of the [the architecture
 document][architecture] first. While it's not a comprehensive document, it gives a good hint of where you should start
-looking to make your changes. As always, if you're not sure [do ask the community][community]!
+looking to make your changes. As always, if you're not sure, [do ask the community][community]!
 
 ### Testing
-When making larger changes, it's may be useful to write a test to make sure your code works as expected.
+When making larger changes, it may be useful to write a test to make sure your code works as expected.
 
 CC: Tweaked has several test suites, each designed to test something different:
 
@@ -91,11 +91,11 @@ file.
 
 Documentation is built using [illuaminate] which, while not currently documented (somewhat ironic), is largely the same
 as [ldoc][ldoc]. Documentation comments are written in Markdown, though note that we do not support many GitHub-specific
-markdown features - if you can, do check what the documentation looks like locally!
+markdown features—if you can, do check what the documentation looks like locally!
 
 When writing long-form documentation (such as the guides in [doc/guides](doc/guides)), I find it useful to tell a
-narrative. Think of what you want the user to learn or achieve, then start introducing a simple concept and then talk
-about how you can build on that, until you've covered everything!
+narrative. Think of what you want the user to learn or achieve, then start introducing a simple concept, and then talk
+about how you can build on that until you've covered everything!
 
 [new-issue]: https://github.com/cc-tweaked/CC-Tweaked/issues/new/choose "Create a new issue"
 [community]: README.md#community "Get in touch with the community."


### PR DESCRIPTION
I've fixed a typo where `installed` was spelled incorrectly. I've also fixed some grammar issues and changed some styles. I'm not going to list them all up, the file comparison in GitHub should show them well 😅 

Maybe you do not agree with every change, just let me know what you don't like, and I'm gonna change it back